### PR TITLE
Scaffold contract endpoint

### DIFF
--- a/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractTests.cs
+++ b/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractTests.cs
@@ -1,0 +1,22 @@
+namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Contracts.PrepareContract;
+
+public sealed class PrepareContractTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _applicationHttpClient;
+
+    public PrepareContractTests(WebApplicationFactory<Program> applicationInMemoryFactory) =>
+        _applicationHttpClient = applicationInMemoryFactory
+            .CreateClient();
+
+    [Fact]
+    public async Task Given_valid_contract_preparation_request_Then_should_return_created_status_code()
+    {
+        // Arrange
+
+        // Act
+        var prepareContractResponse = await _applicationHttpClient.PostAsync(ApiPaths.Contracts, new StringContent(string.Empty));
+
+        // Assert
+        prepareContractResponse.Should().HaveStatusCode(HttpStatusCode.Created);
+    }
+}

--- a/Src/Fitnet.IntegrationTests/Passes/RegisterPass/RegisterPassRequestFaker.cs
+++ b/Src/Fitnet.IntegrationTests/Passes/RegisterPass/RegisterPassRequestFaker.cs
@@ -1,4 +1,4 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Passes.RegisterPass.Requests;
+namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Passes.RegisterPass;
 
 using SuperSimpleArchitecture.Fitnet.Passes.RegisterPass;
 

--- a/Src/Fitnet.IntegrationTests/Passes/RegisterPass/RegisterPassTests.cs
+++ b/Src/Fitnet.IntegrationTests/Passes/RegisterPass/RegisterPassTests.cs
@@ -3,7 +3,6 @@ namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Passes.RegisterPass;
 using Common.TestEngine;
 using Common.TestEngine.Configuration;
 using Fitnet.Passes.RegisterPass;
-using Requests;
 
 public sealed class RegisterPassTests : IClassFixture<WebApplicationFactory<Program>>, IClassFixture<DatabaseContainer>
 {

--- a/Src/Fitnet.IntegrationTests/Passes/RegisterPass/RegisterPassTests.cs
+++ b/Src/Fitnet.IntegrationTests/Passes/RegisterPass/RegisterPassTests.cs
@@ -1,8 +1,7 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Passes.Register;
+namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Passes.RegisterPass;
 
 using Common.TestEngine;
 using Common.TestEngine.Configuration;
-using Fitnet.Passes;
 using Fitnet.Passes.RegisterPass;
 using Requests;
 

--- a/Src/Fitnet.IntegrationTests/Passes/RegisterPass/Requests/RegisterPassRequestFaker.cs
+++ b/Src/Fitnet.IntegrationTests/Passes/RegisterPass/Requests/RegisterPassRequestFaker.cs
@@ -1,6 +1,6 @@
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Passes.Register.Requests;
+namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Passes.RegisterPass.Requests;
 
-using Fitnet.Passes.RegisterPass;
+using SuperSimpleArchitecture.Fitnet.Passes.RegisterPass;
 
 internal sealed class RegisterPassRequestFaker : Faker<RegisterPassRequest>
 {

--- a/Src/Fitnet/ApiPaths.cs
+++ b/Src/Fitnet/ApiPaths.cs
@@ -1,0 +1,9 @@
+namespace SuperSimpleArchitecture.Fitnet;
+
+public static class ApiPaths
+{
+    private const string Api = "api";
+    
+    public const string Passes = $"{Api}/passes";
+    public const string Contracts = $"{Api}/contracts";
+}

--- a/Src/Fitnet/Contracts/ContractsEndpoints.cs
+++ b/Src/Fitnet/Contracts/ContractsEndpoints.cs
@@ -1,6 +1,6 @@
-using SuperSimpleArchitecture.Fitnet.Contracts.PrepareContract;
-
 namespace SuperSimpleArchitecture.Fitnet.Contracts;
+
+using PrepareContract;
 
 internal static class ContractsEndpoints
 {

--- a/Src/Fitnet/Contracts/ContractsEndpoints.cs
+++ b/Src/Fitnet/Contracts/ContractsEndpoints.cs
@@ -1,0 +1,9 @@
+using SuperSimpleArchitecture.Fitnet.Contracts.PrepareContract;
+
+namespace SuperSimpleArchitecture.Fitnet.Contracts;
+
+internal static class ContractsEndpoints
+{
+    public static void MapContracts(this IEndpointRouteBuilder app) => 
+        app.MapPrepareContract();
+}

--- a/Src/Fitnet/Contracts/PrepareContract/PrepareContractEndpoint.cs
+++ b/Src/Fitnet/Contracts/PrepareContract/PrepareContractEndpoint.cs
@@ -1,0 +1,14 @@
+namespace SuperSimpleArchitecture.Fitnet.Contracts.PrepareContract;
+
+internal static class PrepareContractEndpoint
+{
+    internal static void MapPrepareContract(this IEndpointRouteBuilder app)
+    {
+        app.MapPost(ApiPaths.Contracts, () =>
+        {
+            var fakeContractId = Guid.NewGuid();
+            
+            return Task.FromResult(Results.Created($"/{ApiPaths.Contracts}/{fakeContractId}", fakeContractId));
+        });
+    }
+}

--- a/Src/Fitnet/Passes/ApiPaths.cs
+++ b/Src/Fitnet/Passes/ApiPaths.cs
@@ -1,6 +1,0 @@
-namespace SuperSimpleArchitecture.Fitnet.Passes;
-
-public static class ApiPaths
-{
-    public const string Passes = "api/passes";
-}

--- a/Src/Fitnet/Passes/PassesEndpoints.cs
+++ b/Src/Fitnet/Passes/PassesEndpoints.cs
@@ -5,5 +5,5 @@ using RegisterPass;
 internal static class PassesEndpoints
 {
     public static void MapPasses(this IEndpointRouteBuilder app) => 
-        app.MapRegister();
+        app.MapRegisterPass();
 }

--- a/Src/Fitnet/Passes/RegisterPass/RegisterPassEndpoint.cs
+++ b/Src/Fitnet/Passes/RegisterPass/RegisterPassEndpoint.cs
@@ -5,7 +5,7 @@ using Data.Database;
 
 internal static class RegisterEndpoint
 {
-    internal static void MapRegister(this IEndpointRouteBuilder app)
+    internal static void MapRegisterPass(this IEndpointRouteBuilder app)
     {
         app.MapPost(ApiPaths.Passes, async (RegisterPassRequest request, PassesPersistence persistance) =>
         {


### PR DESCRIPTION
This PR includes all change required to start working on Contracts module with:

- first endpoint of PrepareContract that operates on fake data
- contracts endpoint registration
- unit tests
- naming adjustments in register passes