### PR TITLE
Add sign contract API endpoint

### DIFF
--- a/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractRequestFaker.cs
+++ b/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractRequestFaker.cs
@@ -9,7 +9,8 @@ internal sealed class PrepareContractRequestFaker : Faker<PrepareContractRequest
         CustomInstantiator(faker =>
             new PrepareContractRequest(
                 faker.Random.Number(minAge, maxAge),
-                faker.Random.Number(minHeight, maxHeight)
+                faker.Random.Number(minHeight, maxHeight),
+                DateTimeOffset.Now
             )
         );
     }

--- a/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractRequestFaker.cs
+++ b/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractRequestFaker.cs
@@ -10,7 +10,7 @@ internal sealed class PrepareContractRequestFaker : Faker<PrepareContractRequest
             new PrepareContractRequest(
                 faker.Random.Number(minAge, maxAge),
                 faker.Random.Number(minHeight, maxHeight),
-                DateTimeOffset.Now
+                faker.Date.RecentOffset()
             )
         );
     }

--- a/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractRequestParameters.cs
+++ b/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractRequestParameters.cs
@@ -1,0 +1,7 @@
+namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Contracts;
+
+internal record PrepareContractRequestParameters(int MinAge, int MaxAge, int MinHeight, int MaxHeight)
+{
+    internal static PrepareContractRequestParameters GetValid() => new(18, 100, 0, 210);
+}
+    

--- a/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractTests.cs
+++ b/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractTests.cs
@@ -6,7 +6,8 @@ namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Contracts.PrepareContr
 using Common.TestEngine;
 using Common.TestEngine.Configuration;
 
-public sealed class PrepareContractTests : IClassFixture<WebApplicationFactory<Program>>, IClassFixture<DatabaseContainer>
+public sealed class PrepareContractTests : IClassFixture<WebApplicationFactory<Program>>,
+    IClassFixture<DatabaseContainer>
 {
     private readonly HttpClient _applicationHttpClient;
 
@@ -15,20 +16,19 @@ public sealed class PrepareContractTests : IClassFixture<WebApplicationFactory<P
         _applicationHttpClient = applicationInMemoryFactory
             .WithContainerDatabaseConfigured(database.ConnectionString!)
             .CreateClient();
-    
+
     [Fact]
     public async Task Given_valid_contract_preparation_request_Then_should_return_created_status_code()
     {
         // Arrange
-        const int minAge = 18;
-        const int maxAge = 100;
-        const int minHeight = 0;
-        const int maxHeight = 210;
-        
-        PrepareContractRequest prepareContractRequest = new PrepareContractRequestFaker(minAge, maxAge, minHeight, maxHeight);  
+        var requestParameters = PrepareContractRequestParameters.GetValid();
+
+        PrepareContractRequest prepareContractRequest = new PrepareContractRequestFaker(requestParameters.MinAge,
+            requestParameters.MaxAge, requestParameters.MinHeight, requestParameters.MaxHeight);
 
         // Act
-        var prepareContractResponse = await _applicationHttpClient.PostAsJsonAsync(ContractsApiPaths.Prepare, prepareContractRequest);
+        var prepareContractResponse =
+            await _applicationHttpClient.PostAsJsonAsync(ContractsApiPaths.Prepare, prepareContractRequest);
 
         // Assert
         prepareContractResponse.Should().HaveStatusCode(HttpStatusCode.Created);

--- a/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractTests.cs
+++ b/Src/Fitnet.IntegrationTests/Contracts/PrepareContract/PrepareContractTests.cs
@@ -1,3 +1,4 @@
+using SuperSimpleArchitecture.Fitnet.Contracts;
 using SuperSimpleArchitecture.Fitnet.Contracts.PrepareContract;
 
 namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Contracts.PrepareContract;
@@ -27,7 +28,7 @@ public sealed class PrepareContractTests : IClassFixture<WebApplicationFactory<P
         PrepareContractRequest prepareContractRequest = new PrepareContractRequestFaker(minAge, maxAge, minHeight, maxHeight);  
 
         // Act
-        var prepareContractResponse = await _applicationHttpClient.PostAsJsonAsync(ApiPaths.Contracts, prepareContractRequest);
+        var prepareContractResponse = await _applicationHttpClient.PostAsJsonAsync(ContractsApiPaths.Prepare, prepareContractRequest);
 
         // Assert
         prepareContractResponse.Should().HaveStatusCode(HttpStatusCode.Created);

--- a/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractRequestFaker.cs
+++ b/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractRequestFaker.cs
@@ -6,8 +6,8 @@ internal sealed class SignContractRequestFaker : Faker<SignContractRequest>
 {
     public SignContractRequestFaker()
     {
-        CustomInstantiator(_ =>
-            new SignContractRequest(DateTimeOffset.Now)
+        CustomInstantiator((faker) =>
+            new SignContractRequest(faker.Date.RecentOffset())
         );
     }
 }

--- a/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractRequestFaker.cs
+++ b/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractRequestFaker.cs
@@ -1,0 +1,13 @@
+using SuperSimpleArchitecture.Fitnet.Contracts.SignContract;
+
+namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Contracts.PrepareContract;
+
+internal sealed class SignContractRequestFaker : Faker<SignContractRequest>
+{
+    public SignContractRequestFaker()
+    {
+        CustomInstantiator(_ =>
+            new SignContractRequest(DateTimeOffset.Now)
+        );
+    }
+}

--- a/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractRequestFaker.cs
+++ b/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractRequestFaker.cs
@@ -1,6 +1,6 @@
 using SuperSimpleArchitecture.Fitnet.Contracts.SignContract;
 
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Contracts.PrepareContract;
+namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Contracts.SignContract;
 
 internal sealed class SignContractRequestFaker : Faker<SignContractRequest>
 {

--- a/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractTests.cs
+++ b/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractTests.cs
@@ -1,0 +1,64 @@
+using SuperSimpleArchitecture.Fitnet.Contracts;
+using SuperSimpleArchitecture.Fitnet.Contracts.PrepareContract;
+
+namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Contracts.PrepareContract;
+
+using Common.TestEngine;
+using Common.TestEngine.Configuration;
+
+public sealed class SignContractTests : IClassFixture<WebApplicationFactory<Program>>, IClassFixture<DatabaseContainer>
+{
+    private readonly HttpClient _applicationHttpClient;
+
+    public SignContractTests(WebApplicationFactory<Program> applicationInMemoryFactory,
+        DatabaseContainer database) =>
+        _applicationHttpClient = applicationInMemoryFactory
+            .WithContainerDatabaseConfigured(database.ConnectionString!)
+            .CreateClient();
+
+    [Fact]
+    public async Task Given_valid_contract_signature_request_Then_should_return_no_content_status_code()
+    {
+        // Arrange
+        var preparedContractId = await PrepareContract();
+        var url = BuildUrl(preparedContractId);
+        var signContractRequest = new SignContractRequestFaker();
+
+        // Act
+        var signContractResponse = await _applicationHttpClient.PatchAsJsonAsync(url, signContractRequest);
+
+        // Assert
+        signContractResponse.Should().HaveStatusCode(HttpStatusCode.NoContent);
+    }
+    
+    [Fact]
+    public async Task Given_contract_signature_request_with_not_existing_id_Then_should_return_not_found()
+    {
+        // Arrange
+        var notExistingId = Guid.NewGuid();
+        var url = BuildUrl(notExistingId);
+        var signContractRequest = new SignContractRequestFaker();
+
+        // Act
+        var signContractResponse = await _applicationHttpClient.PatchAsJsonAsync(url, signContractRequest);
+
+        // Assert
+        signContractResponse.Should().HaveStatusCode(HttpStatusCode.NoContent);
+    }
+
+    private async Task<Guid> PrepareContract()
+    {
+        const int minAge = 18;
+        const int maxAge = 100;
+        const int minHeight = 0;
+        const int maxHeight = 210;
+        
+        PrepareContractRequest prepareContractRequest = new PrepareContractRequestFaker(minAge, maxAge, minHeight, maxHeight);
+        var prepareContractResponse = await _applicationHttpClient.PostAsJsonAsync(ContractsApiPaths.Prepare, prepareContractRequest);
+        var preparedContractId = await prepareContractResponse.Content.ReadFromJsonAsync<Guid>();
+
+        return preparedContractId;
+    }
+
+    private static string BuildUrl(Guid id) => ContractsApiPaths.Prepare.Replace("{id}", id.ToString());
+}

--- a/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractTests.cs
+++ b/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractTests.cs
@@ -1,7 +1,8 @@
 using SuperSimpleArchitecture.Fitnet.Contracts;
 using SuperSimpleArchitecture.Fitnet.Contracts.PrepareContract;
+using SuperSimpleArchitecture.Fitnet.IntegrationTests.Contracts.PrepareContract;
 
-namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Contracts.PrepareContract;
+namespace SuperSimpleArchitecture.Fitnet.IntegrationTests.Contracts.SignContract;
 
 using Common.TestEngine;
 using Common.TestEngine.Configuration;

--- a/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractTests.cs
+++ b/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractTests.cs
@@ -49,13 +49,12 @@ public sealed class SignContractTests : IClassFixture<WebApplicationFactory<Prog
 
     private async Task<Guid> PrepareContract()
     {
-        const int minAge = 18;
-        const int maxAge = 100;
-        const int minHeight = 0;
-        const int maxHeight = 210;
-        
-        PrepareContractRequest prepareContractRequest = new PrepareContractRequestFaker(minAge, maxAge, minHeight, maxHeight);
-        var prepareContractResponse = await _applicationHttpClient.PostAsJsonAsync(ContractsApiPaths.Prepare, prepareContractRequest);
+        var requestParameters = PrepareContractRequestParameters.GetValid();
+
+        PrepareContractRequest prepareContractRequest = new PrepareContractRequestFaker(requestParameters.MinAge,
+            requestParameters.MaxAge, requestParameters.MinHeight, requestParameters.MaxHeight);
+        var prepareContractResponse =
+            await _applicationHttpClient.PostAsJsonAsync(ContractsApiPaths.Prepare, prepareContractRequest);
         var preparedContractId = await prepareContractResponse.Content.ReadFromJsonAsync<Guid>();
 
         return preparedContractId;

--- a/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractTests.cs
+++ b/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractTests.cs
@@ -61,5 +61,5 @@ public sealed class SignContractTests : IClassFixture<WebApplicationFactory<Prog
         return preparedContractId;
     }
 
-    private static string BuildUrl(Guid id) => ContractsApiPaths.Prepare.Replace("{id}", id.ToString());
+    private static string BuildUrl(Guid id) => ContractsApiPaths.Sign.Replace("{id}", id.ToString());
 }

--- a/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractTests.cs
+++ b/Src/Fitnet.IntegrationTests/Contracts/SignContract/SignContractTests.cs
@@ -44,7 +44,7 @@ public sealed class SignContractTests : IClassFixture<WebApplicationFactory<Prog
         var signContractResponse = await _applicationHttpClient.PatchAsJsonAsync(url, signContractRequest);
 
         // Assert
-        signContractResponse.Should().HaveStatusCode(HttpStatusCode.NoContent);
+        signContractResponse.Should().HaveStatusCode(HttpStatusCode.NotFound);
     }
 
     private async Task<Guid> PrepareContract()

--- a/Src/Fitnet/ApiPaths.cs
+++ b/Src/Fitnet/ApiPaths.cs
@@ -3,6 +3,4 @@ namespace SuperSimpleArchitecture.Fitnet;
 public static class ApiPaths
 {
     internal const string Root = "api";
-
-    public const string Contracts = $"{Root}/contracts";
 }

--- a/Src/Fitnet/ApiPaths.cs
+++ b/Src/Fitnet/ApiPaths.cs
@@ -1,6 +1,6 @@
 namespace SuperSimpleArchitecture.Fitnet;
 
-public static class ApiPaths
+internal static class ApiPaths
 {
     internal const string Root = "api";
 }

--- a/Src/Fitnet/Contracts/ContractsApiPaths.cs
+++ b/Src/Fitnet/Contracts/ContractsApiPaths.cs
@@ -2,6 +2,8 @@ namespace SuperSimpleArchitecture.Fitnet.Contracts;
 
 internal static class ContractsApiPaths
 {
-    internal const string Prepare = $"{ApiPaths.Root}/contracts";
-    internal const string Sign = $"{ApiPaths.Root}/contracts/{{id}}";
+    private const string ContractsRootApi = $"{ApiPaths.Root}/contracts";
+    
+    internal const string Prepare = ContractsRootApi;
+    internal const string Sign = $"{ContractsRootApi}/{{id}}";
 }

--- a/Src/Fitnet/Contracts/ContractsApiPaths.cs
+++ b/Src/Fitnet/Contracts/ContractsApiPaths.cs
@@ -1,0 +1,6 @@
+namespace SuperSimpleArchitecture.Fitnet.Contracts;
+
+internal static class ContractsApiPaths
+{
+    internal const string Prepare = $"{ApiPaths.Root}/contracts";
+}

--- a/Src/Fitnet/Contracts/ContractsApiPaths.cs
+++ b/Src/Fitnet/Contracts/ContractsApiPaths.cs
@@ -3,4 +3,5 @@ namespace SuperSimpleArchitecture.Fitnet.Contracts;
 internal static class ContractsApiPaths
 {
     internal const string Prepare = $"{ApiPaths.Root}/contracts";
+    internal const string Sign = $"{ApiPaths.Root}/contracts/{{id}}";
 }

--- a/Src/Fitnet/Contracts/ContractsEndpoints.cs
+++ b/Src/Fitnet/Contracts/ContractsEndpoints.cs
@@ -1,9 +1,15 @@
+using SuperSimpleArchitecture.Fitnet.Contracts.SignContract;
+
 namespace SuperSimpleArchitecture.Fitnet.Contracts;
 
 using PrepareContract;
 
 internal static class ContractsEndpoints
 {
-    public static void MapContracts(this IEndpointRouteBuilder app) => 
+    internal static void MapContracts(this IEndpointRouteBuilder app)
+    {
         app.MapPrepareContract();
+        app.MapSignContract();
+    }
+        
 }

--- a/Src/Fitnet/Contracts/ContractsEndpoints.cs
+++ b/Src/Fitnet/Contracts/ContractsEndpoints.cs
@@ -11,5 +11,4 @@ internal static class ContractsEndpoints
         app.MapPrepareContract();
         app.MapSignContract();
     }
-        
 }

--- a/Src/Fitnet/Contracts/Data/Contract.cs
+++ b/Src/Fitnet/Contracts/Data/Contract.cs
@@ -8,6 +8,8 @@ internal sealed class Contract
     public Guid Id { get; init; }
     
     public DateTimeOffset PreparedAt { get; init; }
+    
+    public DateTimeOffset SignedAt { get; private set; }
 
     private Contract(Guid id, DateTimeOffset preparedAt)
     {
@@ -22,4 +24,6 @@ internal sealed class Contract
         
         return new(Guid.NewGuid(), preparedAt);
     }
+
+    public void Sign(DateTimeOffset signedAt) => SignedAt = signedAt;
 }

--- a/Src/Fitnet/Contracts/Data/Contract.cs
+++ b/Src/Fitnet/Contracts/Data/Contract.cs
@@ -6,17 +6,20 @@ namespace SuperSimpleArchitecture.Fitnet.Contracts.Data;
 internal sealed class Contract
 {
     public Guid Id { get; init; }
+    
+    public DateTimeOffset PreparedAt { get; init; }
 
-    private Contract(Guid id)
+    private Contract(Guid id, DateTimeOffset preparedAt)
     {
         Id = id;
+        PreparedAt = preparedAt;
     }
 
-    internal static Contract Prepare(int customerAge, int customerHeight)
+    internal static Contract Prepare(int customerAge, int customerHeight, DateTimeOffset preparedAt)
     {
         BusinessRuleValidator.Validate(new ContractCanBePreparedOnlyForAdultRule(customerAge));
         BusinessRuleValidator.Validate(new CustomerMustBeSmallerThanMaximumHeightLimitRule(customerHeight));
         
-        return new(Guid.NewGuid());
+        return new(Guid.NewGuid(), preparedAt);
     }
 }

--- a/Src/Fitnet/Contracts/Data/Database/ContractEntityConfiguration.cs
+++ b/Src/Fitnet/Contracts/Data/Database/ContractEntityConfiguration.cs
@@ -9,5 +9,6 @@ internal sealed class ContractEntityConfiguration : IEntityTypeConfiguration<Con
     {
         builder.ToTable("Contracts");
         builder.HasKey(contract => contract.Id);
+        builder.Property(contract => contract.PreparedAt).IsRequired();
     }
 }

--- a/Src/Fitnet/Contracts/Data/Database/Migrations/20230407115944_AddPreparedAtDate.Designer.cs
+++ b/Src/Fitnet/Contracts/Data/Database/Migrations/20230407115944_AddPreparedAtDate.Designer.cs
@@ -2,18 +2,21 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SuperSimpleArchitecture.Fitnet.Contracts.Data.Database;
 
 #nullable disable
 
-namespace SuperSimpleArchitecture.Fitnet.Migrations
+namespace SuperSimpleArchitecture.Fitnet.Migrations.ContractsPersistenceMigrations
 {
     [DbContext(typeof(ContractsPersistence))]
-    partial class ContractsPersistenceModelSnapshot : ModelSnapshot
+    [Migration("20230407115944_AddPreparedAtDate")]
+    partial class AddPreparedAtDate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Src/Fitnet/Contracts/Data/Database/Migrations/20230407115944_AddPreparedAtDate.cs
+++ b/Src/Fitnet/Contracts/Data/Database/Migrations/20230407115944_AddPreparedAtDate.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SuperSimpleArchitecture.Fitnet.Migrations.ContractsPersistenceMigrations
+{
+    /// <inheritdoc />
+    public partial class AddPreparedAtDate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "PreparedAt",
+                schema: "Contracts",
+                table: "Contracts",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: DateTimeOffset.Now);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PreparedAt",
+                schema: "Contracts",
+                table: "Contracts");
+        }
+    }
+}

--- a/Src/Fitnet/Contracts/Data/Database/Migrations/20230407123603_AddSignedAtDate.Designer.cs
+++ b/Src/Fitnet/Contracts/Data/Database/Migrations/20230407123603_AddSignedAtDate.Designer.cs
@@ -2,18 +2,21 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SuperSimpleArchitecture.Fitnet.Contracts.Data.Database;
 
 #nullable disable
 
-namespace SuperSimpleArchitecture.Fitnet.Migrations
+namespace SuperSimpleArchitecture.Fitnet.Migrations.ContractsPersistenceMigrations
 {
     [DbContext(typeof(ContractsPersistence))]
-    partial class ContractsPersistenceModelSnapshot : ModelSnapshot
+    [Migration("20230407123603_AddSignedAtDate")]
+    partial class AddSignedAtDate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Src/Fitnet/Contracts/Data/Database/Migrations/20230407123603_AddSignedAtDate.cs
+++ b/Src/Fitnet/Contracts/Data/Database/Migrations/20230407123603_AddSignedAtDate.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SuperSimpleArchitecture.Fitnet.Migrations.ContractsPersistenceMigrations
+{
+    /// <inheritdoc />
+    public partial class AddSignedAtDate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "SignedAt",
+                schema: "Contracts",
+                table: "Contracts",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: DateTimeOffset.Now);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SignedAt",
+                schema: "Contracts",
+                table: "Contracts");
+        }
+    }
+}

--- a/Src/Fitnet/Contracts/PrepareContract/PrepareContractEndpoint.cs
+++ b/Src/Fitnet/Contracts/PrepareContract/PrepareContractEndpoint.cs
@@ -7,13 +7,13 @@ internal static class PrepareContractEndpoint
 {
     internal static void MapPrepareContract(this IEndpointRouteBuilder app)
     {
-        app.MapPost(ApiPaths.Contracts, async (PrepareContractRequest request, ContractsPersistence persistence) =>
+        app.MapPost(ContractsApiPaths.Prepare, async (PrepareContractRequest request, ContractsPersistence persistence) =>
         {
             var contract = Contract.Prepare(request.CustomerAge, request.CustomerHeight, request.PreparedAt);
             await persistence.Contracts.AddAsync(contract);
             await persistence.SaveChangesAsync();
 
-            return Results.Created($"/{ApiPaths.Contracts}/{contract.Id}", contract.Id);
+            return Results.Created($"/{ContractsApiPaths.Prepare}/{contract.Id}", contract.Id);
         });
     }
 }

--- a/Src/Fitnet/Contracts/PrepareContract/PrepareContractEndpoint.cs
+++ b/Src/Fitnet/Contracts/PrepareContract/PrepareContractEndpoint.cs
@@ -9,7 +9,7 @@ internal static class PrepareContractEndpoint
     {
         app.MapPost(ApiPaths.Contracts, async (PrepareContractRequest request, ContractsPersistence persistence) =>
         {
-            var contract = Contract.Prepare(request.CustomerAge, request.CustomerHeight);
+            var contract = Contract.Prepare(request.CustomerAge, request.CustomerHeight, request.PreparedAt);
             await persistence.Contracts.AddAsync(contract);
             await persistence.SaveChangesAsync();
 

--- a/Src/Fitnet/Contracts/PrepareContract/PrepareContractRequest.cs
+++ b/Src/Fitnet/Contracts/PrepareContract/PrepareContractRequest.cs
@@ -1,3 +1,3 @@
 namespace SuperSimpleArchitecture.Fitnet.Contracts.PrepareContract;
 
-public record PrepareContractRequest(int CustomerAge, int CustomerHeight);
+public record PrepareContractRequest(int CustomerAge, int CustomerHeight, DateTimeOffset PreparedAt);

--- a/Src/Fitnet/Contracts/SignContract/SignContractEndpoint.cs
+++ b/Src/Fitnet/Contracts/SignContract/SignContractEndpoint.cs
@@ -1,0 +1,21 @@
+namespace SuperSimpleArchitecture.Fitnet.Contracts.SignContract;
+
+using Data.Database;
+
+internal static class SignContractEndpoint
+{
+    internal static void MapSignContract(this IEndpointRouteBuilder app)
+    {
+        app.MapPatch(ContractsApiPaths.Sign, async (Guid id, SignContractRequest request, ContractsPersistence persistence) =>
+        {
+            var contract = await persistence.Contracts.FindAsync(id);
+            if (contract is null)
+                return Results.NotFound();
+
+            contract.Sign(request.SignedAt);
+            await persistence.SaveChangesAsync();
+
+            return Results.NoContent();
+        });
+    }
+}

--- a/Src/Fitnet/Contracts/SignContract/SignContractRequest.cs
+++ b/Src/Fitnet/Contracts/SignContract/SignContractRequest.cs
@@ -1,0 +1,3 @@
+namespace SuperSimpleArchitecture.Fitnet.Contracts.SignContract;
+
+public record SignContractRequest(DateTimeOffset SignedAt);

--- a/Src/Fitnet/Fitnet.csproj
+++ b/Src/Fitnet/Fitnet.csproj
@@ -15,5 +15,9 @@
     <ItemGroup>
         <InternalsVisibleTo Include="SuperSimpleArchitecture.Fitnet.UnitTests" />
     </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="SuperSimpleArchitecture.Fitnet.IntegrationTests" />
+    </ItemGroup>
     
 </Project>


### PR DESCRIPTION
This PR contains following changes:

- extension of contract with PreparedAt date (this will be needed to compare it with SignedAt date with business rules that will be introduced in a separate branch) as required field
- extension of contract with SignedAt date as non required field
- extension of existing API endpoint for contract preparation to store the date
- creation of new API endpoint for contract signature (without business rules)